### PR TITLE
Update AnnotatedString to use Kotlin Immutable Collection

### DIFF
--- a/androidutilities/src/main/java/com/heyzeusv/androidutilities/compose/annotatedstring/HyperlinkAnnotatedString.kt
+++ b/androidutilities/src/main/java/com/heyzeusv/androidutilities/compose/annotatedstring/HyperlinkAnnotatedString.kt
@@ -12,6 +12,7 @@ import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.core.text.toSpanned
+import kotlinx.collections.immutable.ImmutableMap
 
 private const val HTTPS = "https://"
 
@@ -23,7 +24,7 @@ fun hyperlinkAnnotatedString(
     text: String,
     textStyle: TextStyle,
     linkStyle: TextStyle? = null,
-    linkTextToHyperlinks: Map<String, String>,
+    linkTextToHyperlinks: ImmutableMap<String, String>,
     linkTextColor: Color = Color.Blue,
     linkTextFontWeight: FontWeight = FontWeight.Normal,
     linkTextDecoration: TextDecoration = TextDecoration.Underline,
@@ -61,7 +62,7 @@ fun hyperlinkAnnotatedString(
     @StringRes textId: Int,
     textStyle: TextStyle,
     linkStyle: TextStyle? = null,
-    linkTextToHyperlinks: Map<String, String>,
+    linkTextToHyperlinks: ImmutableMap<String, String>,
     linkTextColor: Color = Color.Blue,
     linkTextFontWeight: FontWeight = FontWeight.Normal,
     linkTextDecoration: TextDecoration = TextDecoration.Underline,

--- a/androidutilities/src/main/java/com/heyzeusv/androidutilities/compose/annotatedstring/HyperlinkText.kt
+++ b/androidutilities/src/main/java/com/heyzeusv/androidutilities/compose/annotatedstring/HyperlinkText.kt
@@ -10,6 +10,7 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.style.TextOverflow
+import kotlinx.collections.immutable.ImmutableMap
 
 @Composable
 fun HyperlinkText(
@@ -17,7 +18,7 @@ fun HyperlinkText(
     text: String,
     textStyle: TextStyle,
     linkStyle: TextStyle? = null,
-    linkTextToHyperlinks: Map<String, String>,
+    linkTextToHyperlinks: ImmutableMap<String, String>,
     linkTextColor: Color = Color.Blue,
     linkTextFontWeight: FontWeight = FontWeight.Normal,
     linkTextDecoration: TextDecoration = TextDecoration.Underline,
@@ -54,7 +55,7 @@ fun HyperlinkText(
     @StringRes textId: Int,
     textStyle: TextStyle,
     linkStyle: TextStyle? = null,
-    linkTextToHyperlinks: Map<String, String>,
+    linkTextToHyperlinks: ImmutableMap<String, String>,
     linkTextColor: Color = Color.Blue,
     linkTextFontWeight: FontWeight = FontWeight.Normal,
     linkTextDecoration: TextDecoration = TextDecoration.Underline,

--- a/app/src/main/java/com/heyzeusv/androidutilitieslibrary/AnnotatedString.kt
+++ b/app/src/main/java/com/heyzeusv/androidutilitieslibrary/AnnotatedString.kt
@@ -11,6 +11,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextDecoration
 import com.heyzeusv.androidutilities.compose.annotatedstring.HyperlinkText
+import kotlinx.collections.immutable.persistentMapOf
 
 @Composable
 fun AnnotatedStringScreen() {
@@ -22,7 +23,7 @@ fun AnnotatedStringScreen() {
         HyperlinkText(
             text = "Testing hyper link composable",
             textStyle = MaterialTheme.typography.headlineLarge,
-            linkTextToHyperlinks = mapOf(
+            linkTextToHyperlinks = persistentMapOf(
                 "Testing" to "github.com",
                 "composable" to "https://medium.com",
             ),
@@ -31,7 +32,7 @@ fun AnnotatedStringScreen() {
             text = "Testing hyper link composable",
             textStyle = MaterialTheme.typography.bodySmall,
             linkStyle = MaterialTheme.typography.displayLarge,
-            linkTextToHyperlinks = mapOf(
+            linkTextToHyperlinks = persistentMapOf(
                 "Testing" to "github.com",
                 "composable" to "https://medium.com",
             ),
@@ -42,7 +43,7 @@ fun AnnotatedStringScreen() {
         HyperlinkText(
             textId = R.string.hyperlink_example,
             textStyle = MaterialTheme.typography.headlineLarge,
-            linkTextToHyperlinks = mapOf(
+            linkTextToHyperlinks = persistentMapOf(
                 "LINK1" to "github.com",
                 "LINK2" to "https://medium.com",
             ),


### PR DESCRIPTION
Updated Hyperlink AnnotatedString/Text to use ImmutableMap rather than Map in order to make functions stable and skippable.